### PR TITLE
feat: add Anthropic Claude backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StoryForge
 
-StoryForge is a command-line tool that generates illustrated children's stories using Google's Gemini AI. Simply provide a story prompt, and StoryForge will create both a short story and accompanying AI-generated images.
+StoryForge is a command-line tool that generates illustrated children's stories using AI language models. Simply provide a story prompt, and StoryForge will create both a short story and accompanying AI-generated images. Supports both Google's Gemini AI and Anthropic's Claude AI backends.
 
 ## Features
 
@@ -41,17 +41,41 @@ If you don't have pipx:
 
 ## Setup
 
-### 1. Get a Gemini API Key
+### Choose Your AI Backend
 
-Visit [Google AI Studio](https://aistudio.google.com/) to get your free Gemini API key.
+StoryForge supports multiple AI backends. Choose one or set up both:
 
-### 2. Set Environment Variable
+#### Option 1: Google Gemini (Full Features)
+**Supports:** Story generation + Image generation
 
+1. Visit [Google AI Studio](https://aistudio.google.com/) to get your free Gemini API key
+2. Set the environment variable:
 ```bash
 export GEMINI_API_KEY=your_api_key_here
 ```
 
-Add this to your shell profile (`.bashrc`, `.zshrc`, etc.) to make it permanent.
+#### Option 2: Anthropic Claude (Text Only)
+**Supports:** Story generation only (excellent quality)
+
+1. Visit [Anthropic Console](https://console.anthropic.com/) to get your Claude API key
+2. Set the environment variable:
+```bash
+export ANTHROPIC_API_KEY=your_api_key_here
+```
+
+#### Option 3: Hybrid Setup (Best of Both)
+Set up both backends for maximum flexibility:
+```bash
+export GEMINI_API_KEY=your_gemini_key_here
+export ANTHROPIC_API_KEY=your_anthropic_key_here
+```
+
+Add these to your shell profile (`.bashrc`, `.zshrc`, etc.) to make them permanent.
+
+**Backend Selection:**
+- StoryForge automatically detects available backends
+- Prefers Gemini for full features, falls back to others
+- Use `LLM_BACKEND=anthropic` to force Claude for text generation
 
 ## Usage
 
@@ -92,6 +116,12 @@ storyforge "A brave mouse goes on an adventure" \
 - **Tone**: `gentle`, `exciting`, `silly`, `heartwarming`, `magical`
 - **Theme**: `courage`, `kindness`, `teamwork`, `problem_solving`, `creativity`
 - **Image Style**: `chibi`, `realistic`, `cartoon`, `watercolor`, `sketch`
+
+### Backend-Specific Notes
+
+- **Gemini**: Supports both story and image generation in one tool
+- **Claude**: Excellent story quality, but requires Gemini for images
+- **Hybrid**: Use `LLM_BACKEND=anthropic` for Claude stories + Gemini for images
 
 ## Tab Completion
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "google-genai>=1.23.0",
+    "anthropic>=0.28.0",
     "pillow>=11.2.1",
     "textual[syntax]>=0.54.1",
     "textual-dev>=0.00.1",

--- a/storyforge/StoryForge.py
+++ b/storyforge/StoryForge.py
@@ -1,5 +1,6 @@
 """
-StoryForge: Simplified CLI for generating illustrated stories using Gemini LLM backend.
+StoryForge: Simplified CLI for generating illustrated stories using multiple LLM backends.
+Supports Google Gemini and Anthropic Claude backends.
 """
 
 import os
@@ -19,7 +20,7 @@ from .prompt import Prompt
 console = Console()
 
 # Create Typer app instance for entrypoint
-app = typer.Typer(help="StoryForge: Generate illustrated stories using Gemini LLM backend")
+app = typer.Typer(help="StoryForge: Generate illustrated stories using AI language models (Gemini/Claude)")
 
 
 def generate_default_output_dir() -> str:
@@ -171,9 +172,14 @@ def main(
     try:
         # Initialize backend
         if verbose:
-            console.print("[dim]Initializing Gemini backend...[/dim]")
+            console.print("[dim]Initializing AI backend...[/dim]")
 
         backend = get_backend()
+
+        if verbose:
+            # Show which backend was selected
+            backend_name = type(backend).__name__.replace("Backend", "")
+            console.print(f"[dim]Using {backend_name} backend[/dim]")
 
         # Load context files if --use-context is enabled (default).
         try:
@@ -443,6 +449,12 @@ def main(
                 style="bold",
             )
             console.print("[dim]Please set your Gemini API key: export GEMINI_API_KEY=your_key_here[/dim]")
+        elif "ANTHROPIC_API_KEY" in str(e):
+            console.print(
+                "[red]Error:[/red] ANTHROPIC_API_KEY environment variable not set.",
+                style="bold",
+            )
+            console.print("[dim]Please set your Anthropic API key: export ANTHROPIC_API_KEY=your_key_here[/dim]")
         else:
             console.print(f"[red]Error:[/red] {e}", style="bold")
         raise typer.Exit(1) from e

--- a/storyforge/anthropic_backend.py
+++ b/storyforge/anthropic_backend.py
@@ -1,0 +1,228 @@
+"""
+AnthropicBackend: Implementation of LLMBackend using Anthropic's Claude API.
+Provides methods to generate stories and text-based content using Claude models.
+Note: Claude does not support image generation, so image-related methods return None.
+"""
+
+import os
+
+import anthropic
+
+from .llm_backend import LLMBackend
+from .prompt import Prompt
+
+
+class AnthropicBackend(LLMBackend):
+    """
+    LLM backend implementation using Anthropic's Claude API.
+    Requires ANTHROPIC_API_KEY environment variable to be set.
+
+    Note: This backend only supports text generation. Image generation
+    methods will return None since Claude cannot generate images.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the Anthropic client using the API key from environment variables.
+
+        Raises:
+            RuntimeError: If ANTHROPIC_API_KEY is not set.
+        """
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise RuntimeError("ANTHROPIC_API_KEY environment variable not set.")
+        self.client = anthropic.Anthropic(api_key=api_key)
+
+    def generate_story(self, prompt: Prompt) -> str:
+        """
+        Generate a story based on the given Prompt object using Claude.
+
+        Args:
+            prompt (Prompt): A Prompt object containing comprehensive story
+                generation parameters including context, style, tone, etc.
+
+        Returns:
+            str: The generated story, or an error message on failure.
+        """
+        try:
+            # Use the Prompt's comprehensive prompt building
+            story_prompt = prompt.story
+
+            response = self.client.messages.create(
+                model="claude-3-5-sonnet-20241022",
+                max_tokens=4000,
+                temperature=0.7,
+                messages=[{"role": "user", "content": story_prompt}],
+            )
+
+            # Extract the story text from the response with proper null checking
+            if response.content and len(response.content) > 0:
+                # Claude returns a list of content blocks, get the first text block
+                for content_block in response.content:
+                    if content_block.type == "text" and hasattr(content_block, "text"):
+                        return content_block.text.strip()
+
+            return "[Error: No valid response from Claude]"
+        except Exception as e:
+            # Return a generic error message if generation fails
+            return f"[Error generating story: {str(e)}]"
+
+    def generate_image(
+        self, prompt: Prompt, reference_image_bytes: bytes | None = None
+    ) -> tuple[object | None, bytes | None]:
+        """
+        Claude does not support image generation, so this method returns None.
+
+        Args:
+            prompt (Prompt): A Prompt object containing image generation parameters.
+            reference_image_bytes (Optional[bytes]): Reference image bytes (unused).
+
+        Returns:
+            Tuple[None, None]: Always returns None since Claude cannot generate images.
+        """
+        # Claude cannot generate images, so we return None
+        # This allows the application to handle this gracefully or use a different backend
+        return None, None
+
+    def generate_image_name(self, prompt: Prompt, story: str) -> str:
+        """
+        Generate a short, creative, and descriptive filename for an image
+        illustrating the story using Claude's text generation capabilities.
+
+        Args:
+            prompt (Prompt): A Prompt object containing the original parameters.
+            story (str): The generated story.
+
+        Returns:
+            str: A suggested filename (no spaces or special characters), or
+            'story_image' on failure.
+        """
+        try:
+            # Use the Prompt's comprehensive image name prompt building
+            name_prompt = prompt.image_name(story)
+
+            response = self.client.messages.create(
+                model="claude-3-5-sonnet-20241022",
+                max_tokens=100,
+                temperature=0.3,  # Lower temperature for more consistent naming
+                messages=[{"role": "user", "content": name_prompt}],
+            )
+
+            # Extract name with proper null checking
+            if response.content and len(response.content) > 0:
+                for content_block in response.content:
+                    if content_block.type == "text" and hasattr(content_block, "text"):
+                        name = content_block.text.strip()
+                        # Remove file extension if present
+                        name = name.split(".")[0]
+                        # Clean up any unwanted characters
+                        name = "".join(c for c in name if c.isalnum() or c == "_")
+                        return name if name else "story_image"
+
+            return "story_image"
+        except Exception:
+            # Fallback filename
+            return "story_image"
+
+    def generate_image_prompt(self, story: str, context: str, num_prompts: int) -> list[str]:
+        """
+        Break the given story into detailed image prompts using Claude's understanding.
+        Each prompt will be incredibly detailed for use with external image generation services.
+
+        Args:
+            story (str): The generated story to break into image prompts.
+            context (str): Additional context for the story.
+            num_prompts (int): The number of image prompts to return.
+
+        Returns:
+            list[str]: A list of detailed image prompts describing scenes from the story.
+        """
+        try:
+            # Create a comprehensive prompt for Claude to generate image descriptions
+            image_prompt_request = (
+                f"Please break this story into {num_prompts} detailed, progressive image prompts "
+                f"that would be perfect for generating illustrations. Each prompt should be "
+                f"incredibly detailed, focusing on visual elements like character appearance, "
+                f"setting details, colors, lighting, and mood.\n\n"
+                f"Story: {story}\n\n"
+            )
+
+            if context:
+                image_prompt_request += f"Context: {context}\n\n"
+
+            image_prompt_request += (
+                f"Return exactly {num_prompts} image prompts, each on a new line, numbered 1-{num_prompts}. "
+                f"Each should be child-friendly, detailed, and suitable for AI image generation."
+            )
+
+            response = self.client.messages.create(
+                model="claude-3-5-sonnet-20241022",
+                max_tokens=2000,
+                temperature=0.5,
+                messages=[{"role": "user", "content": image_prompt_request}],
+            )
+
+            # Extract and parse the prompts
+            if response.content and len(response.content) > 0:
+                for content_block in response.content:
+                    if content_block.type == "text" and hasattr(content_block, "text"):
+                        text = content_block.text.strip()
+                        # Parse numbered prompts from Claude's response
+                        lines = text.split("\n")
+                        prompts: list[str] = []
+
+                        for line in lines:
+                            line = line.strip()
+                            # Look for numbered lines like "1. " or "1) "
+                            if line and (line[0].isdigit() or line.startswith(str(len(prompts) + 1))):
+                                # Remove the number and clean up
+                                cleaned = line
+                                for prefix in [
+                                    f"{len(prompts) + 1}. ",
+                                    f"{len(prompts) + 1}) ",
+                                    f"{len(prompts) + 1}: ",
+                                ]:
+                                    if cleaned.startswith(prefix):
+                                        cleaned = cleaned[len(prefix) :]
+                                        break
+                                if cleaned:
+                                    prompts.append(cleaned)
+
+                        # If we got the right number of prompts, return them
+                        if len(prompts) == num_prompts:
+                            return prompts
+
+            # Fallback: Simple story-based prompts
+            return self._generate_fallback_image_prompts(story, context, num_prompts)
+
+        except Exception:
+            # Fallback to simple story-based prompts
+            return self._generate_fallback_image_prompts(story, context, num_prompts)
+
+    def _generate_fallback_image_prompts(self, story: str, context: str, num_prompts: int) -> list[str]:
+        """
+        Generate fallback image prompts when Claude API fails.
+
+        Args:
+            story (str): The story text.
+            context (str): Additional context.
+            num_prompts (int): Number of prompts needed.
+
+        Returns:
+            list[str]: Simple fallback image prompts.
+        """
+        # Simple fallback: split story into paragraphs, or repeat the story if not enough
+        paragraphs = [p.strip() for p in story.split("\n") if p.strip()]
+        prompts = []
+
+        for i in range(num_prompts):
+            if i < len(paragraphs):
+                base = paragraphs[i]
+            else:
+                base = story
+            prompt = f"Create a detailed, child-friendly illustration for this part of the story: {base}"
+            if context:
+                prompt += f"\nContext: {context}"
+            prompts.append(prompt)
+
+        return prompts

--- a/storyforge/llm_backend.py
+++ b/storyforge/llm_backend.py
@@ -165,10 +165,9 @@ def get_backend(backend_name: str | None = None) -> LLMBackend:
             )
 
         elif backend_name == "anthropic":
-            # Future implementation
-            raise RuntimeError(
-                "Anthropic backend not yet implemented. Please use Gemini backend by setting GEMINI_API_KEY."
-            )
+            from .anthropic_backend import AnthropicBackend
+
+            return AnthropicBackend()
 
         else:
             raise RuntimeError(f"Unknown backend '{backend_name}'. Supported backends: gemini (more coming soon)")
@@ -203,9 +202,22 @@ def list_available_backends() -> dict:
             "reason": "google-genai package not installed",
         }
 
+    # Check Anthropic
+    try:
+        import anthropic  # noqa: F401
+
+        has_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
+        backends["anthropic"] = {
+            "available": has_key,
+            "reason": "Ready" if has_key else "ANTHROPIC_API_KEY not set",
+        }
+    except ImportError:
+        backends["anthropic"] = {
+            "available": False,
+            "reason": "anthropic package not installed",
+        }
+
     # Future backends would be checked here
     backends["openai"] = {"available": False, "reason": "Not yet implemented"}
-
-    backends["anthropic"] = {"available": False, "reason": "Not yet implemented"}
 
     return backends

--- a/tests/test_anthropic_backend.py
+++ b/tests/test_anthropic_backend.py
@@ -1,0 +1,338 @@
+"""
+Tests for AnthropicBackend implementation.
+Following the same testing patterns as test_gemini_backend.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from storyforge.anthropic_backend import AnthropicBackend
+from storyforge.prompt import Prompt
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_anthropic_backend_init_success(mock_anthropic):
+    """Test successful initialization of AnthropicBackend."""
+    AnthropicBackend()
+    mock_anthropic.assert_called_once_with(api_key="test_key")
+
+
+def test_anthropic_backend_init_no_api_key():
+    """Test AnthropicBackend initialization fails without API key."""
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(RuntimeError) as exc_info:
+            AnthropicBackend()
+        assert "ANTHROPIC_API_KEY environment variable not set" in str(exc_info.value)
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_story_success(mock_anthropic):
+    """Test successful story generation."""
+    backend = AnthropicBackend()
+
+    # Mock response structure
+    mock_content_block = MagicMock()
+    mock_content_block.type = "text"
+    mock_content_block.text = "A wonderful story about adventure"
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_story(prompt)
+
+    assert result == "A wonderful story about adventure"
+    mock_client.messages.create.assert_called_once()
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_story_no_content(mock_anthropic):
+    """Test story generation when response has no content."""
+    backend = AnthropicBackend()
+
+    mock_response = MagicMock()
+    mock_response.content = []
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_story(prompt)
+
+    assert result == "[Error: No valid response from Claude]"
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_story_non_text_content(mock_anthropic):
+    """Test story generation when response has non-text content blocks."""
+    backend = AnthropicBackend()
+
+    # Mock non-text content block
+    mock_content_block = MagicMock()
+    mock_content_block.type = "tool_use"  # Not text
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_story(prompt)
+
+    assert result == "[Error: No valid response from Claude]"
+
+
+@patch.dict("os.environ", {"anthROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_story_api_error(mock_anthropic):
+    """Test story generation when API call fails."""
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.side_effect = Exception("API Error")
+
+    prompt = Prompt(prompt="test prompt")
+    result = AnthropicBackend().generate_story(prompt)
+
+    assert "Error generating story: API Error" in result
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_always_returns_none(mock_anthropic):
+    """Test that generate_image always returns None since Claude can't generate images."""
+    backend = AnthropicBackend()
+
+    prompt = Prompt(prompt="test prompt")
+    image, image_bytes = backend.generate_image(prompt)
+
+    assert image is None
+    assert image_bytes is None
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_with_reference_returns_none(mock_anthropic):
+    """Test that generate_image returns None even with reference image."""
+    backend = AnthropicBackend()
+
+    prompt = Prompt(prompt="test prompt")
+    image, image_bytes = backend.generate_image(prompt, reference_image_bytes=b"test_bytes")
+
+    assert image is None
+    assert image_bytes is None
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_name_success(mock_anthropic):
+    """Test successful image name generation."""
+    backend = AnthropicBackend()
+
+    mock_content_block = MagicMock()
+    mock_content_block.type = "text"
+    mock_content_block.text = "brave_mouse_adventure"
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_image_name(prompt, "A story about a brave mouse")
+
+    assert result == "brave_mouse_adventure"
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_name_with_extension(mock_anthropic):
+    """Test image name generation removes file extensions."""
+    backend = AnthropicBackend()
+
+    mock_content_block = MagicMock()
+    mock_content_block.type = "text"
+    mock_content_block.text = "brave_mouse_adventure.png"
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_image_name(prompt, "A story about a brave mouse")
+
+    assert result == "brave_mouse_adventure"
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_name_cleans_special_chars(mock_anthropic):
+    """Test image name generation cleans special characters."""
+    backend = AnthropicBackend()
+
+    mock_content_block = MagicMock()
+    mock_content_block.type = "text"
+    mock_content_block.text = "brave-mouse adventure@123!"
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_image_name(prompt, "A story about a brave mouse")
+
+    assert result == "bravemouseadventure123"
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_name_api_error(mock_anthropic):
+    """Test image name generation fallback on API error."""
+    backend = AnthropicBackend()
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.side_effect = Exception("API Error")
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_image_name(prompt, "A story about a brave mouse")
+
+    assert result == "story_image"
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_name_empty_response(mock_anthropic):
+    """Test image name generation fallback on empty response."""
+    backend = AnthropicBackend()
+
+    mock_content_block = MagicMock()
+    mock_content_block.type = "text"
+    mock_content_block.text = ""
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    prompt = Prompt(prompt="test prompt")
+    result = backend.generate_image_name(prompt, "A story about a brave mouse")
+
+    assert result == "story_image"
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_prompt_success(mock_anthropic):
+    """Test successful image prompt generation."""
+    backend = AnthropicBackend()
+
+    mock_content_block = MagicMock()
+    mock_content_block.type = "text"
+    mock_content_block.text = (
+        "1. A brave little mouse stands at the edge of a dark forest\n"
+        "2. The mouse discovers a magical golden acorn glowing softly\n"
+        "3. The mouse returns home triumphantly with the treasure"
+    )
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    result = backend.generate_image_prompt("A brave mouse story", "forest context", 3)
+
+    expected = [
+        "A brave little mouse stands at the edge of a dark forest",
+        "The mouse discovers a magical golden acorn glowing softly",
+        "The mouse returns home triumphantly with the treasure",
+    ]
+    assert result == expected
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_prompt_api_error_fallback(mock_anthropic):
+    """Test image prompt generation uses fallback on API error."""
+    backend = AnthropicBackend()
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.side_effect = Exception("API Error")
+
+    story = "A brave mouse went on an adventure.\nThe mouse found treasure.\nThe mouse returned home."
+    result = backend.generate_image_prompt(story, "forest context", 2)
+
+    assert len(result) == 2
+    assert "brave mouse went on an adventure" in result[0].lower()
+    assert "forest context" in result[0]
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+@patch("storyforge.anthropic_backend.anthropic.Anthropic")
+def test_generate_image_prompt_wrong_number_fallback(mock_anthropic):
+    """Test image prompt generation uses fallback when wrong number of prompts returned."""
+    backend = AnthropicBackend()
+
+    mock_content_block = MagicMock()
+    mock_content_block.type = "text"
+    mock_content_block.text = "1. Only one prompt returned"
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content_block]
+
+    mock_client = mock_anthropic.return_value
+    mock_client.messages.create.return_value = mock_response
+
+    story = "A brave mouse story"
+    result = backend.generate_image_prompt(story, "context", 3)
+
+    # Should use fallback and return 3 prompts
+    assert len(result) == 3
+    assert all("brave mouse story" in prompt.lower() for prompt in result)
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+def test_generate_fallback_image_prompts():
+    """Test the fallback image prompt generation method."""
+    backend = AnthropicBackend()
+
+    story = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+    context = "Forest setting"
+
+    result = backend._generate_fallback_image_prompts(story, context, 2)
+
+    assert len(result) == 2
+    assert "First paragraph" in result[0]
+    assert "Forest setting" in result[0]
+    assert "Second paragraph" in result[1]
+    assert "Forest setting" in result[1]
+
+
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
+def test_generate_fallback_image_prompts_fewer_paragraphs():
+    """Test fallback when story has fewer paragraphs than requested prompts."""
+    backend = AnthropicBackend()
+
+    story = "Only one paragraph."
+    context = "Forest setting"
+
+    result = backend._generate_fallback_image_prompts(story, context, 3)
+
+    assert len(result) == 3
+    # First prompt uses the paragraph, others use full story
+    assert "Only one paragraph" in result[0]
+    assert all("Forest setting" in prompt for prompt in result)


### PR DESCRIPTION
Add comprehensive support for Anthropic's Claude API as an alternative LLM backend:

- Implement AnthropicBackend with story generation capabilities
- Add automatic backend detection (prefers Gemini, falls back to Claude)
- Support hybrid setups using both APIs for different features
- Claude provides text-only generation (no image support)
- Add comprehensive test suite for Anthropic backend
- Update documentation with setup instructions for multiple backends
- Add LLM_BACKEND environment variable for explicit backend selection

Dependencies: Add anthropic>=0.28.0 to requirements